### PR TITLE
mkdocs: remove excess vertical space in block math equations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ markdown_extensions:
   - admonition
   - pymdownx.arithmatex:
       generic: true
+      block_tag: "p"
   - footnotes
   - pymdownx.details
   - pymdownx.superfences


### PR DESCRIPTION
|Before|After|
|-------|------|
|  ![image](https://github.com/user-attachments/assets/4f9dc574-5a2b-40d5-84b7-1c34e3109fe7)        |   ![image](https://github.com/user-attachments/assets/bcef83e5-9d5c-4541-bf31-862cc09a1337)      |

Either I missed something, or it's Arithmatex's issue with KaTeX. Apparently, changing the block wrapper tag from `div` to `p` fixes the issue, but there might be a nicer solution.